### PR TITLE
feat: 消息发送框现在在输入法正在拼写时按回车也不会发送没打完的字了

### DIFF
--- a/src/views/Music.vue
+++ b/src/views/Music.vue
@@ -188,7 +188,7 @@
                 <mu-text-field
                   :value="chatMessage"
                   @input="updateChatMessage"
-                  @keydown.enter="sendHandler"
+                  @keydown="messageFieldEnterHandler"
                   placeholder="Message..."
                   color="primary"
                   class="width-size-100 chat-message"
@@ -1242,6 +1242,12 @@ export default {
       }
       if (stompClient !== null) {
         this.$store.commit("setStompClient", stompClient);
+      }
+    },
+    messageFieldEnterHandler: function(e) {
+      // 按下回车时判断是否发送消息，如果按下的是回车键并且没有按下 shift 键且没有正在输入中文，则发送消息
+      if (e.keyCode === 13 && !e.shiftKey && !e.isComposing) {
+        this.sendHandler();
       }
     },
     sendHandler: function() {


### PR DESCRIPTION
聊天区的消息输入框在检测到回车按下时会直接把消息发送出去，对中英文混打的输入法或日语输入法很不友好。

参考：https://developer.mozilla.org/zh-CN/docs/Web/API/KeyboardEvent/isComposing